### PR TITLE
German language revised

### DIFF
--- a/languages/de/default.php
+++ b/languages/de/default.php
@@ -13,9 +13,9 @@
  * Miscellaneous
  */
 $GLOBALS['TL_LANG']['MSC']['events_subscriptions.subscribe']               = 'Anmelden';
-$GLOBALS['TL_LANG']['MSC']['events_subscriptions.subscribeWaitingList']    = 'Auf eine Warteliste setzen';
+$GLOBALS['TL_LANG']['MSC']['events_subscriptions.subscribeWaitingList']    = 'Auf die Warteliste setzen';
 $GLOBALS['TL_LANG']['MSC']['events_subscriptions.unsubscribe']             = 'Abmelden';
-$GLOBALS['TL_LANG']['MSC']['events_subscriptions.unsubscribeWaitingList']  = 'Von einer Warteliste abmelden';
+$GLOBALS['TL_LANG']['MSC']['events_subscriptions.unsubscribeWaitingList']  = 'Von der Warteliste abmelden';
 $GLOBALS['TL_LANG']['MSC']['events_subscriptions.subscribeConfirmation']   = 'Sie haben sich für das Event angemeldet.';
 $GLOBALS['TL_LANG']['MSC']['events_subscriptions.unsubscribeConfirmation'] = 'Sie haben sich vom Event abgemeldet.';
 $GLOBALS['TL_LANG']['MSC']['events_subscriptions.subscribeNotAllowed']     = 'Anmeldung zu diesem Event ist nicht mehr möglich.';
@@ -24,9 +24,14 @@ $GLOBALS['TL_LANG']['MSC']['events_subscriptions.onWaitingList']           = 'Wa
 $GLOBALS['TL_LANG']['MSC']['events_subscriptions.enableReminders']         = 'Sende mir eine Erinnerung für dieses Event';
 $GLOBALS['TL_LANG']['MSC']['events_subscriptions.canSubscribeUntil']       = 'Anmeldung möglich bis: %s';
 $GLOBALS['TL_LANG']['MSC']['events_subscriptions.canUnsubscribeUntil']     = 'Abmeldung möglich bis: %s';
+$GLOBALS['TL_LANG']['MSC']['events_subscriptions.numberOfParticipants']    = 'Anzahl der Teilnehmer';
+$GLOBALS['TL_LANG']['MSC']['events_subscriptions.numberOfParticipantsExceeded'] = 'Leider können Sie sich nicht anmelden, da die maximale Teilnehmerzahl für dieses Event %d beträgt.';
+$GLOBALS['TL_LANG']['MSC']['events_subscriptions.numberOfParticipantsExceededWaitingList'] = 'Leider können Sie sich nicht anmelden, da die maximale Teilnehmerzahl für dieses Event %d beträgt mit einer zusätzlichen Warteliste von %d Plätzen.';
+$GLOBALS['TL_LANG']['MSC']['events_subscriptions.numberOfParticipantsSubscribeToWaitingList'] = 'Leider können Sie sich nicht anmelden, da die maximale Teilnehmerzahl für dieses Event %d beträgt. Für eine Anmeldung auf die Warteliste senden Sie das Formular bitte erneut.';
 $GLOBALS['TL_LANG']['MSC']['events_subscriptions.guestForm.firstname']     = 'Vorname';
 $GLOBALS['TL_LANG']['MSC']['events_subscriptions.guestForm.lastname']      = 'Nachname';
 $GLOBALS['TL_LANG']['MSC']['events_subscriptions.guestForm.email']         = 'E-Mail-Adresse';
+$GLOBALS['TL_LANG']['MSC']['events_subscriptions.subscribedListHeadline']  = 'Teilnehmer';
 
 /**
  * Errors

--- a/languages/de/default.php
+++ b/languages/de/default.php
@@ -31,7 +31,6 @@ $GLOBALS['TL_LANG']['MSC']['events_subscriptions.numberOfParticipantsSubscribeTo
 $GLOBALS['TL_LANG']['MSC']['events_subscriptions.guestForm.firstname']     = 'Vorname';
 $GLOBALS['TL_LANG']['MSC']['events_subscriptions.guestForm.lastname']      = 'Nachname';
 $GLOBALS['TL_LANG']['MSC']['events_subscriptions.guestForm.email']         = 'E-Mail-Adresse';
-$GLOBALS['TL_LANG']['MSC']['events_subscriptions.subscribedListHeadline']  = 'Teilnehmer';
 
 /**
  * Errors

--- a/languages/de/tl_calendar.php
+++ b/languages/de/tl_calendar.php
@@ -18,7 +18,7 @@ $GLOBALS['TL_LANG']['tl_calendar']['subscription_enable']       = [
 ];
 $GLOBALS['TL_LANG']['tl_calendar']['subscription_reminders']    = [
     'Erinnerungen aktivieren',
-    'Aktiviert Erinnerungen per E-Mail für im Kalender eingetragene Events.',
+    'Aktiviere Erinnerungen per E-Mail für Events dieses Kalenders.',
 ];
 $GLOBALS['TL_LANG']['tl_calendar']['subscription_time']         = [
     'Sendezeit',
@@ -30,30 +30,42 @@ $GLOBALS['TL_LANG']['tl_calendar']['subscription_days']         = [
 ];
 $GLOBALS['TL_LANG']['tl_calendar']['subscription_notification'] = [
     'Benachrichtigung für Erinnerungen',
-    'Bitte wählen Sie die Benachrichtung, welche die Erinnerung versenden soll.',
+    'Bitte wählen Sie die Benachrichtigung, welche die Erinnerung versenden soll.',
 ];
 $GLOBALS['TL_LANG']['tl_calendar']['subscription_skipWaitingListReminders'] = [
-    'Erinnerungen für Anmeldungen auf der Wartelise deaktivieren',
-    'Sede keine Erinnerung für Besucher, welche auf zur Zeit auf der Warteliste stehen.',
+    'Erinnerungen für Anmeldungen auf der Wartelise überspringen',
+    'Sende keine Erinnerungen für Besucher, welche zur Zeit auf der Warteliste stehen.',
 ];
 $GLOBALS['TL_LANG']['tl_calendar']['subscription_unsubscribeLinkPage'] = [
     'Link zur Seite mit der Abmeldebestätigung',
-    'Hier können Sie die Seite wählen, welche angezeigt wird nachdem der Besucher sich per eindeutigem Link aus einer erhaltenen E-Mail abmeldet.',
+    'Hier können Sie die Seite wählen, welche angezeigt wird wenn der Besucher sich per eindeutigem Link aus einer erhaltenen E-Mail abmeldet.',
 ];
 $GLOBALS['TL_LANG']['tl_calendar']['subscription_subscribeNotification'] = [
     'Benachrichtigung über Anmeldung',
-    'Hier können Sie eine benutzerdefinierte Benachrichtigung für die Anmeldung wählen, die anstelle aller Benachrichtigungen dieses Typs verwendet wird.',
+    'Hier können Sie eine benutzerdefinierte Benachrichtigung für die Anmeldung wählen, die anstelle der Standard-Benachrichtigungen dieses Typs verwendet wird.',
 ];
 $GLOBALS['TL_LANG']['tl_calendar']['subscription_unsubscribeNotification'] = [
     'Benachrichtigung über Abmeldung',
-    'Hier können Sie eine benutzerdefinierte Benachrichtigung für die Abmeldung wählen, die anstelle aller Benachrichtigungen dieses Typs verwendet wird.',
+    'Hier können Sie eine benutzerdefinierte Benachrichtigung für die Abmeldung wählen, die anstelle der Standard-Benachrichtigungen dieses Typs verwendet wird.',
 ];
 $GLOBALS['TL_LANG']['tl_calendar']['subscription_listUpdateNotification'] = [
     'Benachrichtigung über Veränderung der Warteliste',
-    'Hier können Sie eine benutzerdefinierte Benachrichtigung über Anderungen in der Warteliste wählen, die anstelle aller Benachrichtigungen dieses Typs verwendet wird.',
+    'Hier können Sie eine benutzerdefinierte Benachrichtigung über Anderungen in der Warteliste wählen, die anstelle der Standard-Benachrichtigungen dieses Typs verwendet wird.',
 ];
 
 /**
  * Legends
  */
 $GLOBALS['TL_LANG']['tl_calendar']['subscription_legend'] = 'Anmeldung Einstellungen';
+
+/**
+ * Buttons
+ */
+$GLOBALS['TL_LANG']['tl_calendar']['subscriptions_overview'] = ['Anmeldungen Übersicht', 'Zeige eine Übersicht der Anmeldungen des Kalenders ID %s'];
+
+/**
+ * Reference
+ */
+$GLOBALS['TL_LANG']['tl_calendar']['subscriptions_overview.headline'] = 'Anmeldeübersicht für Kalender "%s"';
+$GLOBALS['TL_LANG']['tl_calendar']['subscriptions_overview.empty'] = 'Derzeit gibt es keine Anmeldungen.';
+$GLOBALS['TL_LANG']['tl_calendar']['subscriptions_overview.waitingList'] = 'Warteliste';

--- a/languages/de/tl_calendar_events.php
+++ b/languages/de/tl_calendar_events.php
@@ -18,7 +18,7 @@ $GLOBALS['TL_LANG']['tl_calendar_events']['subscription_override']           = [
 ];
 $GLOBALS['TL_LANG']['tl_calendar_events']['subscription_types']              = [
     'Erlaubte Anmelde-Typen',
-    'Hier können Sie die die erlaubten Anmelde-Typen auswählen.',
+    'Hier können Sie die erlaubten Anmelde-Typen auswählen.',
 ];
 $GLOBALS['TL_LANG']['tl_calendar_events']['subscription_maximum']            = [
     'Maximale Anzahl der Anmeldungen',
@@ -32,9 +32,10 @@ $GLOBALS['TL_LANG']['tl_calendar_events']['subscription_unsubscribeEndTime'] = [
     'Abmeldefrist',
     'Hier können Sie den Zeitversatz vor Beginn des Events festlegen ab wann eine Abmeldung nicht mehr möglich ist. Lassen Sie das Feld leer, wenn Sie dies nicht benötigen.'
 ];
+$GLOBALS['TL_LANG']['tl_calendar_events']['subscription_numberOfParticipants'] = ['Enable number of participants', 'Erlaube die Angabe einer Anzahl an Teilnehmern bei der Anmeldung'];
 $GLOBALS['TL_LANG']['tl_calendar_events']['subscription_waitingList']        = [
     'Warteliste aktivieren',
-    'Erlauben Sie die Anmeldung über eine Warteliste.',
+    'Erlauben Sie die Anmeldung auf die Warteliste.',
 ];
 $GLOBALS['TL_LANG']['tl_calendar_events']['subscription_waitingListLimit']   = [
     'Warteliste begrenzen',
@@ -60,8 +61,9 @@ $GLOBALS['TL_LANG']['tl_calendar_events']['subscription_legend'] = ' Anmeldung E
  */
 $GLOBALS['TL_LANG']['tl_calendar_events']['subscriptions'] = [
     'Anmeldungen',
-    'Zeigt die Anmeldungen für Event ID %s.',
+    'Zeigt die Anmeldungen zu Event ID %s.',
 ];
+$GLOBALS['TL_LANG']['tl_calendar_events']['sendNotifications'] = ['Event-Benachrichtigungen senden', 'Benachrichtigungen über Event ID %s senden'];
 
 /**
  * Reference

--- a/languages/de/tl_calendar_events_subscription.php
+++ b/languages/de/tl_calendar_events_subscription.php
@@ -24,18 +24,22 @@ $GLOBALS['TL_LANG']['tl_calendar_events_subscription']['disableReminders'] = [
     'Erinnerungen deaktivieren',
     'Event Erinnerungen für diesen Teilnehmer nicht aktivieren.',
 ];
+$GLOBALS['TL_LANG']['tl_calendar_events_subscription']['numberOfParticipants'] = [
+    'Anzahl der Teilnehmer',
+    'Hier können Sie die Anzahl der Teilnehmer eingeben.',
+];
 $GLOBALS['TL_LANG']['tl_calendar_events_subscription']['member'] = [
     'Mitglied',
     'Bitte wählen Sie das Mitglied, das Sie für das Event anmelden möchten.',
 ];
-$GLOBALS['TL_LANG']['tl_calendar_events_subscription']['firstname'] = ['Vorname', 'Bitte tragen Sie den Vornamen ein.'];
-$GLOBALS['TL_LANG']['tl_calendar_events_subscription']['lastname'] = ['Nachname', 'Bitte tragen Sie den Nachnamen ein.'];
+$GLOBALS['TL_LANG']['tl_calendar_events_subscription']['firstname'] = ['Vorname', 'Bitte geben Sie den Vornamen ein.'];
+$GLOBALS['TL_LANG']['tl_calendar_events_subscription']['lastname'] = ['Nachname', 'Bitte geben Sie den Nachnamen ein.'];
 $GLOBALS['TL_LANG']['tl_calendar_events_subscription']['email'] = [
     'E-Mail-Adresse',
-    'Bitte tragen Sie die E-Mail-Adresse ein.',
+    'Bitte geben Sie die E-Mail-Adresse ein.',
 ];
 $GLOBALS['TL_LANG']['tl_calendar_events_subscription']['dateCreated'] = ['Erstellt am'];
-$GLOBALS['TL_LANG']['tl_calendar_events_subscription']['lastReminder'] = ['Letzte Erinnerung am'];
+$GLOBALS['TL_LANG']['tl_calendar_events_subscription']['lastReminder'] = ['Letzte gesendete Erinnerung'];
 $GLOBALS['TL_LANG']['tl_calendar_events_subscription']['unsubscribeToken'] = ['Abmelde-Token'];
 
 /**
@@ -50,7 +54,7 @@ $GLOBALS['TL_LANG']['tl_calendar_events_subscription']['member_legend'] = 'Mitgl
  */
 $GLOBALS['TL_LANG']['tl_calendar_events_subscription']['new'] = [
     'Neue Anmeldung',
-    'Erstellen Sie eine neue Anmeldung.'
+    'Erstellen Sie eine neue Anmeldung',
 ];
 $GLOBALS['TL_LANG']['tl_calendar_events_subscription']['show'] = [
     'Anmeldung Details',
@@ -77,16 +81,16 @@ $GLOBALS['TL_LANG']['tl_calendar_events_subscription']['typeRef'] = [
 /**
  * Miscellaneous
  */
-$GLOBALS['TL_LANG']['tl_calendar_events_subscription']['summary'] = 'Es gibt %s Anmeldungen für dieses Event.';
+$GLOBALS['TL_LANG']['tl_calendar_events_subscription']['summary'] = 'Es gibt %s Anmeldung(en) für dieses Event.';
 $GLOBALS['TL_LANG']['tl_calendar_events_subscription']['summaryMax'] = 'Es gibt %s von %s möglichen Anmeldungen zu diesem Event.';
 
 /**
  * Export
  */
 $GLOBALS['TL_LANG']['tl_calendar_events_subscription']['export.headline'] = 'Anmeldungen exportieren';
-$GLOBALS['TL_LANG']['tl_calendar_events_subscription']['export.explanation'] = 'Sie sind dabei, die Daten dieses Events zu exportieren:';
-$GLOBALS['TL_LANG']['tl_calendar_events_subscription']['export.count'] = 'Anzahl der zu exportierenden Events:';
-$GLOBALS['TL_LANG']['tl_calendar_events_subscription']['export.excelFormatHint'] = 'Um im Excelformat zu exportieren installieren Sie bitte das <strong>phpoffice/phpspreadsheet</strong> Paket. Altrnativ können Sie das veraltete <strong>phpoffice/phpexcel</strong> Paket installieren.';
+$GLOBALS['TL_LANG']['tl_calendar_events_subscription']['export.explanation'] = 'Sie sind dabei, die Anmeldedaten dieses Events zu exportieren:';
+$GLOBALS['TL_LANG']['tl_calendar_events_subscription']['export.count'] = 'Anzahl der zu exportierenden Anmeldungen:';
+$GLOBALS['TL_LANG']['tl_calendar_events_subscription']['export.excelFormatHint'] = 'Um im Excelformat zu exportieren installieren Sie bitte das <strong>phpoffice/phpspreadsheet</strong> Paket. Alternativ können Sie das veraltete <strong>phpoffice/phpexcel</strong> Paket installieren.';
 $GLOBALS['TL_LANG']['tl_calendar_events_subscription']['export.csv'] = 'Export als CSV';
 $GLOBALS['TL_LANG']['tl_calendar_events_subscription']['export.excel'] = 'Export als Excel';
 
@@ -96,8 +100,9 @@ $GLOBALS['TL_LANG']['tl_calendar_events_subscription']['export.excel'] = 'Export
 $GLOBALS['TL_LANG']['tl_calendar_events_subscription']['notification.headline'] = 'Event Benachrichtigungen';
 $GLOBALS['TL_LANG']['tl_calendar_events_subscription']['notification.explanation'] = 'Hier können Sie eine Benachrichtigung zu diesem Event an ausgewählte Mitgliedergruppen senden:';
 $GLOBALS['TL_LANG']['tl_calendar_events_subscription']['notification.notification'] = 'Benachrichtigung';
-$GLOBALS['TL_LANG']['tl_calendar_events_subscription']['notification.memberGroups'] = 'Mitgliedergruppen';
+$GLOBALS['TL_LANG']['tl_calendar_events_subscription']['notification.subscribableMemberGroups'] = 'Mitgliedergruppen mit Anmeldeberechtigung';
+$GLOBALS['TL_LANG']['tl_calendar_events_subscription']['notification.otherMemberGroups'] = 'Andere Mitgliedergruppen';
 $GLOBALS['TL_LANG']['tl_calendar_events_subscription']['notification.submit'] = 'Sende eine Benachrichtigung';
 $GLOBALS['TL_LANG']['tl_calendar_events_subscription']['notification.noRecipients'] = 'Es gibt keine aktiven Mitglieder, an welche diese Benachrichtigung gesendet werden kann.';
 $GLOBALS['TL_LANG']['tl_calendar_events_subscription']['notification.confirmation'] = '%s Benachrichtigungen erfolgreich gesendet!';
-$GLOBALS['TL_LANG']['tl_calendar_events_subscription']['notification.lastNotificationDate'] = 'Letzte Benachrichtigung gesendet am/um %s.';
+$GLOBALS['TL_LANG']['tl_calendar_events_subscription']['notification.lastNotificationDate'] = 'Letzte Benachrichtigung gesendet am %s.';

--- a/languages/de/tl_member.php
+++ b/languages/de/tl_member.php
@@ -18,8 +18,8 @@
  * Fields
  */
 $GLOBALS['TL_LANG']['tl_member']['subscription_enableLimit'] = [
-    'Limit der Anmeldungen aktivieren',
-    'Beschränken Sie die Anmeldungen des Mitglieds. Dies überschreibt die Einstellungen der Mitgliedergruppe! ',
+    'Anmeldelimit aktivieren',
+    'Beschränken Sie die Anmeldungen des Mitglieds. Dies überschreibt die Einstellungen der Mitgliedergruppe!',
 ];
 
 /**

--- a/languages/de/tl_member_group.php
+++ b/languages/de/tl_member_group.php
@@ -14,7 +14,7 @@
  */
 $GLOBALS['TL_LANG']['tl_member_group']['subscription_enableLimit'] = [
     'Anmeldelimit aktivieren',
-    'Begrenzt die Zahl der Anmeldungen für Mitglieder aus dieser Gruppe.',
+    'Begrenzen Sie die Anzahl der Anmeldungen für Mitglieder aus dieser Gruppe.',
 ];
 $GLOBALS['TL_LANG']['tl_member_group']['subscription_totalLimit']  = [
     'Gesamtlimit',

--- a/languages/de/tl_nc_notification.php
+++ b/languages/de/tl_nc_notification.php
@@ -16,5 +16,5 @@ $GLOBALS['TL_LANG']['tl_nc_notification']['type']['events_subscriptions']       
 $GLOBALS['TL_LANG']['tl_nc_notification']['type']['events_subscriptions_reminder']    = ['Event Erinnerung'];
 $GLOBALS['TL_LANG']['tl_nc_notification']['type']['events_subscriptions_subscribe']   = ['Event Anmeldung'];
 $GLOBALS['TL_LANG']['tl_nc_notification']['type']['events_subscriptions_unsubscribe'] = ['Event Abmeldung'];
-$GLOBALS['TL_LANG']['tl_nc_notification']['type']['events_subscriptions_listUpdate'] = ['Warteliste Veränderung'];
+$GLOBALS['TL_LANG']['tl_nc_notification']['type']['events_subscriptions_listUpdate'] = ['Event Warteliste Veränderung'];
 $GLOBALS['TL_LANG']['tl_nc_notification']['type']['events_subscription_event'] = ['Event Benachrichtigung'];

--- a/languages/en/default.php
+++ b/languages/en/default.php
@@ -31,6 +31,7 @@ $GLOBALS['TL_LANG']['MSC']['events_subscriptions.numberOfParticipantsSubscribeTo
 $GLOBALS['TL_LANG']['MSC']['events_subscriptions.guestForm.firstname']     = 'First name';
 $GLOBALS['TL_LANG']['MSC']['events_subscriptions.guestForm.lastname']      = 'Last name';
 $GLOBALS['TL_LANG']['MSC']['events_subscriptions.guestForm.email']         = 'E-mail address';
+$GLOBALS['TL_LANG']['MSC']['events_subscriptions.subscribedListHeadline']  = 'Subscriber';
 
 /**
  * Errors

--- a/languages/en/default.php
+++ b/languages/en/default.php
@@ -31,7 +31,6 @@ $GLOBALS['TL_LANG']['MSC']['events_subscriptions.numberOfParticipantsSubscribeTo
 $GLOBALS['TL_LANG']['MSC']['events_subscriptions.guestForm.firstname']     = 'First name';
 $GLOBALS['TL_LANG']['MSC']['events_subscriptions.guestForm.lastname']      = 'Last name';
 $GLOBALS['TL_LANG']['MSC']['events_subscriptions.guestForm.email']         = 'E-mail address';
-$GLOBALS['TL_LANG']['MSC']['events_subscriptions.subscribedListHeadline']  = 'Subscriber';
 
 /**
  * Errors


### PR DESCRIPTION
Added the missing variables for the new participants feature.

Revised my last german translation.

Added a new simple variable that we can use in FE as headline for the subscribers list.
EN - Subscribers
DE - Teilnehmer
default.php => `$GLOBALS['TL_LANG']['MSC']['events_subscriptions.subscribedListHeadline']  = 'Subscriber';`
